### PR TITLE
Dashboard page capabilities filter hook

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Contributors: crowdfavorite, alexkingorg
 Tags: analytics, google-analytics, email, statistics, stats, dashboard
 Requires at least: 3.1
 Tested up to: 3.4.2
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 
 MailChimp's Analytics360 plugin allows you to pull Google Analytics and MailChimp data directly into your dashboard, so you can access robust analytics tools without leaving WordPress.
 
@@ -77,6 +77,10 @@ Please drop us a line if you find a bug or would like to see a new feature added
 
 
 == Changelog ==
+
+= 1.3.1 =
+
+* Added filter to allow low capabilities users to view Dashboard Stats. Hook: a360_dashboard_capability
 
 = 1.3.0 =
 

--- a/analytics360.php
+++ b/analytics360.php
@@ -3,7 +3,7 @@
 Plugin Name: Analytics360
 Plugin URI: http://www.mailchimp.com/wordpress_analytics_plugin/?pid=wordpress&source=website
 Description: Allows you to pull Google Analytics and MailChimp data directly into your dashboard, so you can access robust analytics tools without leaving WordPress. Compliments of <a href="http://mailchimp.com/">MailChimp</a>.
-Version: 1.3.0
+Version: 1.3.1
 Author: Crowd Favorite
 Author URI: http://crowdfavorite.com
 */
@@ -213,8 +213,13 @@ function a360_show_ga_auth_error($message, $errors = '') {
 	a360_warning_box($message, $errors, $config_warnings);
 }
 
+/**
+ * Added capability filter, so to to enable other users to view stats
+ * used two times in this function
+ */
 function a360_request_handler() {
-	if (!empty($_GET['a360_action']) && current_user_can('manage_options')) {
+	$cap = apply_filters( 'a360_dashboard_capability', 'manage_options' );
+	if (!empty($_GET['a360_action']) && current_user_can($cap)) {
 		switch ($_GET['a360_action']) {
 
 			case 'admin_js':
@@ -513,7 +518,7 @@ function a360_request_handler() {
 			break;
 		}
 	}
-	if (!empty($_POST['a360_action']) && current_user_can('manage_options')) {
+	if (!empty($_POST['a360_action']) && current_user_can($cap)) {
 		a360_check_nonce($_POST['a360_nonce'], $_POST['a360_action']);
 		switch ($_POST['a360_action']) {
 			case 'update_mc_api_key':
@@ -636,8 +641,12 @@ function a360_get_authsub_headers($token = null) {
 	return array('Authorization' => 'AuthSub token="'.$token.'"');
 }
 
+/**
+ * Removed first check for capability, add_*_page already has it
+ * Added capability filter to dashboard, so to to enable other users to view stats
+ */
 function a360_admin_menu() {
-	if (current_user_can('manage_options')) {
+//	if (current_user_can('manage_options')) {
 		add_options_page(
 			__('Settings', 'analytics360'),
 			__('Analytics360°', 'analytics360'),
@@ -648,11 +657,11 @@ function a360_admin_menu() {
 		add_dashboard_page(
 			__('Dashboard', 'analytics360'),
 			__('Analytics360°', 'analytics360'),
-			'manage_options',
+			apply_filters( 'a360_dashboard_capability', 'manage_options' ),
 			basename(__FILE__),
 			'a360_dashboard'
 		);
-	}
+//	}
 }
 add_action('admin_menu', 'a360_admin_menu');
 


### PR DESCRIPTION
Added filter hook to allow other users (non-admins) to view Dashboard Stats.

Changed 3 instances of `'manage_options'` for the filter hook `a360_dashboard_capability`, so as to allow editors or other roles to view the Dashboard Statistics page.

As [discussed](http://wordpress.org/support/topic/feature-request-add-filter-hook-to-allow-editors-viewing-stats) in wp.org forums.
